### PR TITLE
Installscript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 venv
 __pycache__
+*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-btc/__pycache__/
-*.json
+.idea
+.vscode
+venv
+__pycache__

--- a/btc/install.sh
+++ b/btc/install.sh
@@ -1,0 +1,12 @@
+#!/bin/bash 
+
+if [ ! -d "venv" ]
+then
+  echo "Missing venv, installing"
+  python3 -m venv venv
+
+  echo "installing dependencies"
+  ./venv/bin/pip3 install -r requirements.txt
+fi
+
+[ ! -d "venv" ] && echo "Error while creating venv, check errors" && exit 1

--- a/btc/requirements.txt
+++ b/btc/requirements.txt
@@ -1,0 +1,3 @@
+meshtastic
+bdkpython
+pandas


### PR DESCRIPTION
Make in more cleaner and use virtual environment instead of system/user wide pip instalations. It does not work on new systems anyway.


```
petrkr@archlinux ~> pip install some
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try 'pacman -S
    python-xyz', where xyz is the package you are trying to
    install.
```